### PR TITLE
Allow task names to contain dashes

### DIFF
--- a/bake
+++ b/bake
@@ -112,8 +112,8 @@ task_list () {
 
         # search for task name in this format "function task_name" or
         # "task_name ()"
-        if (!($func =~ s/^.*function (\w+).*$/\1/)) {
-            $func =~ s/^(\w+).*\(\).*$/\1/;
+        if (!($func =~ s/^.*function ([\w-]+).*$/\1/)) {
+            $func =~ s/^([\w-]+).*\(\).*$/\1/;
         }
         chomp($func);
         printf "%-16s $desc\n", $func;
@@ -321,4 +321,3 @@ case "$1" in
         fi
         ;;
 esac
-


### PR DESCRIPTION
I'd like to use dashes in my task names, so I can run tasks such as

```
bake build-app
bake deploy-app stage
```
